### PR TITLE
Fix window resize not updating layout on Linux

### DIFF
--- a/fx/linux.odin
+++ b/fx/linux.odin
@@ -401,6 +401,12 @@ handle_event :: proc(event: ^xlib.XEvent) {
 		handle_button(int(event.xbutton.button), false)
 	case .MotionNotify:
 		window.mouse_pos = Vec2{f32(event.xmotion.x), f32(event.xmotion.y)} / dpi_scale()
+	case .ConfigureNotify:
+		new_size := [2]int{int(event.xconfigure.width), int(event.xconfigure.height)}
+		if new_size != window.size {
+			window.size = new_size
+			window.is_resized = true
+		}
 	case .FocusOut:
 		for &state in window.key_state {
 			state = {}


### PR DESCRIPTION
ConfigureNotify wasn't handled, so window.size stayed at its initial value and the UI never reflowed on resize.